### PR TITLE
Fix depwarn

### DIFF
--- a/src/InplaceOps.jl
+++ b/src/InplaceOps.jl
@@ -94,7 +94,7 @@ brdiv!(O::AbstractArray, As...) = broadcast!(/,O,As...)
 
 replace_t(ex) = esc(ex)
 function replace_t(ex::Expr)
-    if ex.head == symbol("'")
+    if ex.head == Symbol("'")
         :(op_ctranspose($(esc(ex.args[1]))))
     elseif ex.head == :(.')
         :(op_transpose($(esc(ex.args[1]))))


### PR DESCRIPTION
```julia
WARNING: symbol is deprecated, use Symbol instead.
 in depwarn(::String, ::Symbol) at .\deprecated.jl:64
 in symbol(::String, ::Vararg{String,N}) at .\deprecated.jl:30
 in replace_t(::Expr) at C:\Users\Chris\.julia\v0.6\InplaceOps\src\InplaceOps.jl:97
 in collect_to!(::Array{Expr,1}, ::Base.Generator{Array{Any,1},InplaceOps.#replace_t}, ::Int64, ::Int64) at .\array.jl:341
 in collect_to_with_first!(::Array{Expr,1}, ::Expr, ::Base.Generator{Array{Any,1},InplaceOps.#replace_t}, ::Int64) at .\array.jl:328
 in collect(::Base.Generator{Array{Any,1},InplaceOps.#replace_t}) at .\array.jl:309
 in @into!(::Any) at C:\Users\Chris\.julia\v0.6\InplaceOps\src\InplaceOps.jl:120
 in include_from_node1(::String) at .\loading.jl:426 (repeats 2 times)
 in macro expansion; at .\none:2 [inlined]
 in anonymous at .\<missing>:?
 in eval(::Module, ::Any) at .\boot.jl:234
 in process_options(::Base.JLOptions) at .\client.jl:239
 in _start() at .\client.jl:318
```