### PR TITLE
Add support for simple += expressions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+Manifest*.toml

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,16 @@
+name = "InplaceOps"
+uuid = "505f98c9-085e-5b2c-8e89-488be7bf1f34"
+authors = ["Simon Byrne <simonbyrne@gmail.com> and contributors"]
+version = "0.3.0"
+
+[deps]
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
+[compat]
+julia = "0.7, 1"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ InplaceOps.jl provides a macro `@!` which rewrites expressions of the form:
 - `C = C/B` or `C /= B` to `rdiv!(C,B)`
 - `C = A\B` to `ldiv!(C,A,B)`
 - `C = A\C` to `ldiv!(A,B)`
+- `C += A*B` to `mul!(C,A,B,true,true)`
+- `C += A*B*alpha` to `mul!(C,A,B,alpha,true)`
 
 Functionality for broadcasting is no longer supported. Use the Base `@.` macro instead.
 

--- a/src/InplaceOps.jl
+++ b/src/InplaceOps.jl
@@ -15,6 +15,24 @@ macro !(ex)
         else
             error("Invalid use of @! macro")
         end
+    elseif ex.head == :+=
+        op = ex.head
+        C, ex2 = ex.args
+        if ex2.head == :call
+            ex2.args[1] == :* || error("@! macro only supports multiplication to the right of +=")
+            A = ex2.args[2]
+            B = ex2.args[3]
+            nargs = length(ex2.args)
+            if nargs == 3
+                alpha = true
+            elseif nargs == 4
+                alpha = ex2.args[4]
+            else
+                error("@! macro only supports 2- and 3-argument multiplication")
+            end
+        else
+            error("Invalid use of @! macro")
+        end
     elseif ex.head in (:*=, :/=)
         op = Symbol(String(ex.head)[1:1])
         C = A = ex.args[1]
@@ -51,6 +69,9 @@ macro !(ex)
         else
             return :($(esc(C)) = mul!($(esc(C)), $(esc(A)), $(esc(B))))
         end
+    elseif op == :+=
+        beta = true
+        return :($(esc(C)) = mul!($(esc(C)), $(esc(A)), $(esc(B)), $(esc(alpha)), $beta))
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,7 @@ using Test, LinearAlgebra
 n = 10
 
 X = randn(n,n)
+Y = randn(n,n)
 
 v = randn(n)
 v_orig = v
@@ -44,3 +45,15 @@ Z_check = X * X'
 @! Z = X * X'
 @test Z == Z_check
 @test Z === Z_orig
+
+Z_check = Z + X * Y
+@! Z += X * Y
+@test Z == Z_check
+@test Z === Z_orig
+
+alpha = 3
+Z_check = Z + X * Y * alpha
+@! Z += X * Y * alpha
+@test Z == Z_check
+@test Z === Z_orig
+@test_throws Exception @macroexpand @! Z += X * Y * 3 * 4


### PR DESCRIPTION
Happy new year! :tada:

I've added a `Project.toml` using the UUID from [General](https://github.com/JuliaRegistries/General/blob/master/I/InplaceOps/Package.toml), so I could more easily `pkg> test` the package.

I did not implement `-=` because I found it non-trivial to choose a proper `-1`: should it be `-one(promote_type(eltype(B), eltype(C)))`, or `-oneunit(...)`, or `-Int8(1)`, or else. In exchange, I've added support for `C += A * B * alpha` so the user may chose a proper `-1` himself/herself.

Closes #18.

---

Given the package has not seen a release in 8 years, I would say it is fairly stable. On top of that, the package has a [fair amount of monthly downloads](https://juliahub.com/ui/Packages/General/InplaceOps); 62 over the past 30 days that include the Christmas break. What is your stance on creating a v1 release?